### PR TITLE
Add #[DisableQueryTracking] attribute to opt out individual tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -618,6 +618,61 @@ abstract class TestCase extends BaseTestCase
 
 This will fail any test that has N+1 queries, duplicate queries, or missing indexes. Consider starting with a subset of tests rather than your entire suite.
 
+### Opting out with `#[DisableQueryTracking]`
+
+In paranoid mode, some tests may need to opt out — for example, tests with heavy seeders, migrations, or tests that intentionally execute many queries. Use the `#[DisableQueryTracking]` attribute to skip tracking for specific tests or entire classes:
+
+```php
+use Mattiasgeniar\PhpunitQueryCountAssertions\Attributes\DisableQueryTracking;
+
+class DashboardTest extends TestCase
+{
+    use AssertsQueryCounts;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->trackQueries();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->assertQueriesAreEfficient();
+        parent::tearDown();
+    }
+
+    // This test is checked normally
+    public function test_dashboard_loads_efficiently(): void
+    {
+        $this->get('/dashboard');
+    }
+
+    // This test opts out of query tracking
+    #[DisableQueryTracking]
+    public function test_heavy_seeder_setup(): void
+    {
+        $this->seed(LargeDatasetSeeder::class);
+        // ...
+    }
+}
+```
+
+You can also disable tracking for an entire test class:
+
+```php
+use Mattiasgeniar\PhpunitQueryCountAssertions\Attributes\DisableQueryTracking;
+
+#[DisableQueryTracking]
+class MigrationTest extends TestCase
+{
+    use AssertsQueryCounts;
+
+    // All tests in this class skip query tracking
+}
+```
+
+When `#[DisableQueryTracking]` is present, `trackQueries()` returns early without setting up listeners, and all assertions (`assertQueriesAreEfficient()`, `assertQueryCountMatches()`, etc.) pass silently.
+
 ## Configurable thresholds
 
 ### MySQL analyser options

--- a/src/Attributes/DisableQueryTracking.php
+++ b/src/Attributes/DisableQueryTracking.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mattiasgeniar\PhpunitQueryCountAssertions\Attributes;
+
+use Attribute;
+
+#[Attribute(Attribute::TARGET_METHOD | Attribute::TARGET_CLASS)]
+class DisableQueryTracking {}

--- a/tests/AssertsQueryCountsTest.php
+++ b/tests/AssertsQueryCountsTest.php
@@ -5,6 +5,7 @@ namespace Mattiasgeniar\PhpunitQueryCountAssertions\Tests;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\DB;
 use Mattiasgeniar\PhpunitQueryCountAssertions\AssertsQueryCounts;
+use Mattiasgeniar\PhpunitQueryCountAssertions\Attributes\DisableQueryTracking;
 use Mattiasgeniar\PhpunitQueryCountAssertions\Tests\Fixtures\Post;
 use Mattiasgeniar\PhpunitQueryCountAssertions\Tests\Fixtures\User;
 use PHPUnit\Framework\AssertionFailedError;
@@ -671,5 +672,33 @@ class AssertsQueryCountsTest extends TestCase
         $this->assertCount(1, $queries);
         $this->assertEquals('SELECT 2', $queries[0]['query']);
         $this->assertEquals('replica', $queries[0]['connection']);
+    }
+
+    #[Test]
+    #[DisableQueryTracking]
+    public function it_silently_passes_assertions_when_tracking_is_disabled(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->assertNoQueriesExecuted();
+        $this->assertQueryCountMatches(0);
+        $this->assertQueryCountLessThan(1);
+    }
+
+    #[Test]
+    #[DisableQueryTracking]
+    public function it_silently_passes_efficient_assertion_when_tracking_is_disabled(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->assertQueriesAreEfficient();
+    }
+
+    #[Test]
+    public function it_still_asserts_normally_without_disable_attribute(): void
+    {
+        DB::select('SELECT 1');
+
+        $this->assertQueryCountMatches(1);
     }
 }

--- a/tests/DisableQueryTrackingClassTest.php
+++ b/tests/DisableQueryTrackingClassTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Mattiasgeniar\PhpunitQueryCountAssertions\Tests;
+
+use Mattiasgeniar\PhpunitQueryCountAssertions\AssertsQueryCounts;
+use Mattiasgeniar\PhpunitQueryCountAssertions\Attributes\DisableQueryTracking;
+use PHPUnit\Framework\Attributes\Test;
+
+#[DisableQueryTracking]
+class DisableQueryTrackingClassTest extends TestCase
+{
+    use AssertsQueryCounts;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->trackQueries();
+    }
+
+    #[Test]
+    public function it_silently_passes_when_class_has_disable_attribute(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->assertQueriesAreEfficient();
+    }
+
+    #[Test]
+    public function it_silently_passes_count_assertions_when_class_has_disable_attribute(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $this->assertNoQueriesExecuted();
+        $this->assertQueryCountMatches(0);
+    }
+}


### PR DESCRIPTION
## Why

In paranoid mode (`trackQueries()` in `setUp`, `assertQueriesAreEfficient()` in `tearDown`), there's no way to opt out individual tests that legitimately need many queries — heavy seeders, migration tests, or intentional stress tests. The only escape hatch is abandoning paranoid mode entirely.

This would resolve https://github.com/mattiasgeniar/phpunit-query-count-assertions/issues/19 

## What changed

- Added a `#[DisableQueryTracking]` PHP attribute that can be placed on a test method or an entire test class to silently skip query tracking and assertions.
- When the attribute is present, `trackQueries()` returns early without setting up listeners, and all assertion methods pass without checking. Closures passed to assertion methods still execute — only the query checks are skipped.